### PR TITLE
Add support for roslaunch to close #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ qtcreator-*
 
 # Catkin custom files
 CATKIN_IGNORE
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -28,13 +28,21 @@ To start off experimenting launch premade gazebo world
 Start Rviz visualizer
 > roslaunch turtlebot3_gazebo turtlebot3_gazebo_rviz.launch
 
-Run from the repository the specific scripts
+Run from the repository the specific script
 > rosrun rpw_impl lidar_detection.py
 
 The controller and the ui nodes can be run similarly
 > rosrun rpw_impl controller.py
 
 > rosrun rpw_impl ui.py
+
+Or to launch all nodes
+> roslaunch rpw_impl ui_and_controller.launch
+
+If you run this from the turtlebot, you should use
+> roslaunch rpw_impl controller_detector.launch
+
+and start the ui separately from the remote pc
 
 ### Add new scripts and/or edit the existing
 

--- a/launch/controller_detector.launch
+++ b/launch/controller_detector.launch
@@ -1,0 +1,22 @@
+<launch>
+    <arg 
+        name="topic_namespace"
+        default="$(optenv ROS_NAMESPACE '')"
+    />
+    <include file="$(find turtlebot3_bringup)/launch/turtlebot3_robot.launch">
+    </include>
+    <node
+        pkg="rpw_impl"
+        type="lidar_detection.py"
+        name="lidar_node"
+        args="--namespace $(arg topic_namespace) --disable_output"
+        output="screen"
+    />
+    <node
+        pkg="rpw_impl"
+        type="controller.py"
+        name="turtlebot_controller"
+        args="--namespace $(arg topic_namespace) --disable_output"
+        output="log"
+    />
+</launch>

--- a/launch/ui_and_controller.launch
+++ b/launch/ui_and_controller.launch
@@ -1,0 +1,27 @@
+<launch>
+    <arg 
+        name="topic_namespace"
+        default="$(optenv ROS_NAMESPACE '')"
+    />
+    <node
+        pkg="rpw_impl"
+        type="lidar_detection.py"
+        name="lidar_node"
+        args="--namespace $(arg topic_namespace) --disable_output"
+        output="screen"
+    />
+    <node
+        pkg="rpw_impl"
+        type="controller.py"
+        name="turtlebot_controller"        
+        args="--namespace $(arg topic_namespace) --disable_output"
+        output="log"
+    />
+    <node
+        pkg="rpw_impl"
+        type="ui.py"
+        name="ui_node"
+        args="--namespace $(arg topic_namespace)"
+        output="screen"
+    />
+</launch>


### PR DESCRIPTION
controller_detector.launch untested as I don't have access to a real turtlebot right now.

Scripts now use ROS_NAMESPACE for all topics.
Can be modified with arguments if needed:
- roslaunch rpw_impl ui_and_controller.launch topic_namespace:=/tb_example
- rosrun rpw_impl ui.py --namespace /tb_example